### PR TITLE
ci: fix golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  go: '1.20'
   timeout: 5m
   modules-download-mode: readonly
 linters:
@@ -10,7 +9,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
 
 issues:
@@ -19,6 +17,6 @@ issues:
     - ".*_test.go"
   exclude-dirs:
     - vendor
-    - examples  
+    - examples
 output:
   formats: colored-line-number


### PR DESCRIPTION
The config was enforced to use Go 1.20 while the go.mod file is using Go 1.22.

golangci-lint detects the version it has to use from the go.mod file. so it's not necessary to enforce it in the config.

Also, there is typecheck linter. typecheck is not a linter but an analyzer.