### PR TITLE
fix: respect Go initialism and acronyms

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,9 +9,15 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - revive
     - staticcheck
     - typecheck
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: var-naming
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,28 @@ linters:
 linters-settings:
   revive:
     rules:
+      - name: blank-imports
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
       - name: var-naming
 
 issues:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ package main
 
 import (
     "fmt"
+
     "github.com/rezmoss/axios4go"
 )
 
@@ -126,7 +127,7 @@ client := axios4go.NewClient("https://api.example.com")
 
 resp, err := client.Request(&axios4go.RequestOptions{
     Method: "GET",
-    Url:    "/users",
+    URL:    "/users",
     Headers: map[string]string{
         "Authorization": "Bearer token",
     },
@@ -200,7 +201,7 @@ resp, err := axios4go.Get("https://api.example.com/data", options)
 `axios4go` supports various configuration options through the `RequestOptions` struct:
 
 - **Method**: HTTP method (`GET`, `POST`, etc.)
-- **Url**: Request URL (relative to `BaseURL` if provided)
+- **URL**: Request URL (relative to `BaseURL` if provided)
 - **BaseURL**: Base URL for the request (overrides client's `BaseURL` if set)
 - **Params**: URL query parameters (`map[string]string`)
 - **Body**: Request body (can be `string`, `[]byte`, or any JSON serializable object)
@@ -224,7 +225,7 @@ resp, err := axios4go.Get("https://api.example.com/data", options)
 ```go
 options := &axios4go.RequestOptions{
     Method: "POST",
-    Url:    "/submit",
+    URL:    "/submit",
     Headers: map[string]string{
         "Content-Type": "application/json",
     },

--- a/axios4go_test.go
+++ b/axios4go_test.go
@@ -701,7 +701,6 @@ func TestValidateStatus(t *testing.T) {
 			t.Errorf("Expected error Request failed with status code: 200, got %v", err.Error())
 		}
 	})
-
 }
 
 func TestInterceptors(t *testing.T) {
@@ -798,7 +797,6 @@ func TestGetByProxy(t *testing.T) {
 				},
 			},
 		)
-
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -906,7 +904,6 @@ func TestProgressCallbacks(t *testing.T) {
 		},
 		MaxContentLength: 2000000, // Set this to allow our 1MB response
 	})
-
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -941,7 +938,7 @@ func TestLogging(t *testing.T) {
 		// Test with sensitive headers
 		reqOptions := &RequestOptions{
 			Method:   "POST",
-			Url:      server.URL + "/post",
+			URL:      server.URL + "/post",
 			LogLevel: LevelDebug,
 			Headers: map[string]string{
 				"Authorization": "Bearer secret-token",
@@ -996,11 +993,10 @@ func TestLogging(t *testing.T) {
 		// Debug level request should not be logged when logger is at Error level
 		_, err := client.Request(&RequestOptions{
 			Method:           "GET",
-			Url:              server.URL + "/get",
+			URL:              server.URL + "/get",
 			LogLevel:         LevelDebug,
 			MaxContentLength: 2000, // Add this line
 		})
-
 		if err != nil {
 			t.Fatalf("Request failed: %v", err)
 		}

--- a/client.go
+++ b/client.go
@@ -431,7 +431,7 @@ func (c *Client) Request(options *RequestOptions) (*Response, error) {
 	c.HTTPClient.Timeout = time.Duration(options.Timeout) * time.Millisecond
 
 	if options.MaxRedirects > 0 {
-		c.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		c.HTTPClient.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
 			if len(via) >= options.MaxRedirects {
 				return http.ErrUseLastResponse
 			}

--- a/client.go
+++ b/client.go
@@ -45,7 +45,7 @@ type InterceptorOptions struct {
 
 type RequestOptions struct {
 	Method             string
-	Url                string
+	URL                string
 	BaseURL            string
 	Params             map[string]string
 	Body               interface{}
@@ -301,7 +301,7 @@ func PatchAsync(urlStr string, body interface{}, options ...*RequestOptions) *Pr
 func Request(method, urlStr string, options ...*RequestOptions) (*Response, error) {
 	reqOptions := &RequestOptions{
 		Method:           "GET",
-		Url:              urlStr,
+		URL:              urlStr,
 		Timeout:          1000,
 		ResponseType:     "json",
 		ResponseEncoding: "utf8",
@@ -333,18 +333,18 @@ func (c *Client) Request(options *RequestOptions) (*Response, error) {
 	var fullURL string
 	if c.BaseURL != "" {
 		var err error
-		fullURL, err = url.JoinPath(c.BaseURL, options.Url)
+		fullURL, err = url.JoinPath(c.BaseURL, options.URL)
 		if err != nil {
 			return nil, err
 		}
 	} else if options.BaseURL != "" {
 		var err error
-		fullURL, err = url.JoinPath(options.BaseURL, options.Url)
+		fullURL, err = url.JoinPath(options.BaseURL, options.URL)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		fullURL = options.Url
+		fullURL = options.URL
 	}
 
 	if len(options.Params) > 0 {
@@ -536,8 +536,8 @@ func mergeOptions(dst, src *RequestOptions) {
 	if src.Method != "" {
 		dst.Method = src.Method
 	}
-	if src.Url != "" {
-		dst.Url = src.Url
+	if src.URL != "" {
+		dst.URL = src.URL
 	}
 	if src.BaseURL != "" {
 		dst.BaseURL = src.BaseURL


### PR DESCRIPTION
This is a breaking change, but the package is still in 0.x.x version.

golangci-lint has been configured to use the revive var-naming rule to enforce this.

Other revive rules were also configured they are the default recommended ones

https://github.com/mgechev/revive/blob/master/defaults.toml
https://golangci-lint.run/usage/linters/#revive
